### PR TITLE
better control over the start of randomisation lists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: randotools
 Title: Create Randomization Lists
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: 
     c(person("Alan G", "Haynes", email = "alan.haynes@unibe.ch", 
              role = c("aut", "cre"),
@@ -12,7 +12,6 @@ URL: https://ctu-bern.github.io/randotools/, https://github.com/CTU-Bern/randoto
 BugReports: https://github.com/CTU-Bern/randotools/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Imports:
     cli,
     dplyr,
@@ -31,3 +30,4 @@ VignetteBuilder: knitr
 Depends: 
     R (>= 4.1)
 LazyData: true
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # randotools 0.2.7
 
-Addition of the ability to prioritize small blocksizes at the start of a randomization list. See `randolist`.
+* Addition of the ability to prioritize small blocksizes at the start of a randomization list. See `randolist`.
+* bug fix: the pascal argument to randolist was ignored. it's not used correctly.
 
 # randotools 0.2.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# randotools 0.2.5
+
+Addition of the ability to prioritize small blocksizes at the start of a randomization list. See `randolist`.
+
 # randotools 0.2.4
 
 bug fix for `check_plan`: it only handled up to 26 strata, producing unexpected results with more strata. It now handles up to 676 strata. 

--- a/R/blockrand.R
+++ b/R/blockrand.R
@@ -15,6 +15,9 @@
 #' @param arms number of arms to randomise
 #' @param blocksizes numbers of each arm to include in blocks
 #' @param pascal logical, whether to use pascal's triangle to determine block sizes
+#' @param n_init number of initial blocks to start the randomisation list with
+#' @param init_probs probabilities to use for each \code{blocksize} for the
+#' first \code{n_init} blocks
 #' @param ... arguments passed on to other methods (currently unused)
 #'
 #' @returns a data frame with columns block, blocksize, seq_in_block, arm
@@ -40,11 +43,20 @@ blockrand <- function(n,
                       arms = LETTERS[seq(2)],
                       blocksizes = 1:4,
                       pascal = TRUE,
+                      n_init = 0,
+                      init_probs = NULL,
                       ...
                       ){
 
   if(n < 2) stop("n too small")
   if(is.null(arms)) stop("arms must be provided")
+  if(n_init > 0){
+    if(is.null(init_probs))
+      stop("'init_probs' must be entered when 'n_init' > 0")
+    if(length(init_probs) != length(blocksizes))
+      stop("'length(init_probs) != length(blocksizes)' : provide probabilities for each blocksize")
+
+  }
 
   N_per_block <- blocksizes * length(arms)
 
@@ -59,6 +71,10 @@ blockrand <- function(n,
 
     # generate block sizes
     blocks <- sample(N_per_block, min_blocks, replace = TRUE, prob = p)
+    if(n_init > 0){
+      init_blocks <- sample(N_per_block, n_init, replace = TRUE, prob = init_probs)
+      blocks <- c(init_blocks, blocks)
+    }
 
     # select blocks to reach n
     blocks <- blocks[1:min(which(cumsum(blocks) >= n))]

--- a/R/randolist.R
+++ b/R/randolist.R
@@ -32,9 +32,21 @@
 #' To disable block randomisation, set \code{blocksizes} to the same value as \code{n}.
 #'
 #' It can be helpful to use smaller blocks at the start of a randomisation list.
-#' \code{n_small} allows you to define how many blocks to add at the beginning of
+#' \code{n_init} allows you to define how many blocks to add at the beginning of
 #' the list with a different set of blocksize probabilities (entered via
-#' \code{init_probs})
+#' \code{init_probs}). Note that this modifies the final frequencies of the
+#' blocksizes - they are no longer according to normal settings (pascals triangle, if
+#' \code{pascal = TRUE}, or approximately equal, if \code{pascal = FALSE}).
+#' Depending on the settings, it may even be that some blocksizes are not observed at
+#' all (e.g. if \code{n_init} exceeds the total number of blocks required and
+#' \code{init_probs = c(.8, .1, 0)}, there will be none of the larger blocks in
+#' the randomisation list.
+#'
+#' \code{n_init} and \code{init_probs} allow more control over the blocksize
+#' probabilities than is otherwise possible (i.e. with the \code{pascal} argument).
+#' Suppose you want primarily blocks of size 2, with some blocks of size 4, you might
+#' set \code{n_init} to \code{n/2} (as if all blocks were of size 2, just to ensure
+#' that there are enough blocks for all randomisations) and set \code{init_probs = c(0.8, .2)}.
 #'
 #' @export
 #'

--- a/R/randolist.R
+++ b/R/randolist.R
@@ -26,6 +26,7 @@
 #' intermediate sized blocks, which helps with making it more difficult to guess
 #' future allocations, and reduces the risk of finishing in the middle of a large
 #' block.
+#' If\code{pascal = FALSE}, all \code{blocksize}s have the same frequency.
 #'
 #' Unbalanced randomization is possible by specifying the same arm label multiple times.
 #'
@@ -83,7 +84,7 @@ randolist <- function(n,
 
   if(!strata_y) {
 
-    rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes,
+    rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes, pascal = pascal,
                        n_init = n_init, init_probs = init_probs, ...)
 
   } else {
@@ -97,7 +98,7 @@ randolist <- function(n,
       stratum <- nth[x]
 
       # generate randomization for this stratum
-      rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes,
+      rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes, pascal = pascal,
                          n_init = n_init, init_probs = init_probs, ...)
 
       # add stratum information to the randomization

--- a/R/randolist.R
+++ b/R/randolist.R
@@ -8,6 +8,10 @@
 #' @param strata named list of stratification variables (see examples)
 #' @param blocksizes numbers of each arm to include in blocks (see details)
 #' @param pascal logical, whether to use pascal's triangle to determine block sizes
+#' @param n_init number of blocks with different blocksize probabilities to
+#' initialize the list with
+#' @param init_probs probabilities to use for each \code{blocksize} for the
+#' \code{n_init} blocks
 #' @param ... arguments passed on to other methods
 #'
 #' @details \code{blocksizes} defines the number of allocations to each arm in a block.
@@ -26,6 +30,11 @@
 #' Unbalanced randomization is possible by specifying the same arm label multiple times.
 #'
 #' To disable block randomisation, set \code{blocksizes} to the same value as \code{n}.
+#'
+#' It can be helpful to use smaller blocks at the start of a randomisation list.
+#' \code{n_small} allows you to define how many blocks to add at the beginning of
+#' the list with a different set of blocksize probabilities (entered via
+#' \code{init_probs})
 #'
 #' @export
 #'
@@ -49,13 +58,21 @@
 #' randolist(10, arms = c("arm 1", "arm 1", "arm 2"))
 #'
 #'
-randolist <- function(n, arms = LETTERS[1:2], strata = NA, blocksizes = 1:3, pascal = TRUE, ...){
+randolist <- function(n,
+                      arms = LETTERS[1:2],
+                      strata = NA,
+                      blocksizes = 1:3,
+                      pascal = TRUE,
+                      n_init = 0,
+                      init_probs = NULL,
+                      ...){
 
   strata_y <- is.list(strata)
 
   if(!strata_y) {
 
-    rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes, ...)
+    rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes,
+                       n_init = n_init, init_probs = init_probs, ...)
 
   } else {
 
@@ -68,7 +85,8 @@ randolist <- function(n, arms = LETTERS[1:2], strata = NA, blocksizes = 1:3, pas
       stratum <- nth[x]
 
       # generate randomization for this stratum
-      rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes, ...)
+      rlist <- blockrand(n = n, arms = arms, blocksizes = blocksizes,
+                         n_init = n_init, init_probs = init_probs, ...)
 
       # add stratum information to the randomization
       rlist$stratum <- stratum

--- a/man/randolist.Rd
+++ b/man/randolist.Rd
@@ -10,6 +10,8 @@ randolist(
   strata = NA,
   blocksizes = 1:3,
   pascal = TRUE,
+  n_init = 0,
+  init_probs = NULL,
   ...
 )
 }
@@ -23,6 +25,12 @@ randolist(
 \item{blocksizes}{numbers of each arm to include in blocks (see details)}
 
 \item{pascal}{logical, whether to use pascal's triangle to determine block sizes}
+
+\item{n_init}{number of blocks with different blocksize probabilities to
+initialize the list with}
+
+\item{init_probs}{probabilities to use for each \code{blocksize} for the
+\code{n_init} blocks}
 
 \item{...}{arguments passed on to other methods}
 }
@@ -53,6 +61,11 @@ block.
 Unbalanced randomization is possible by specifying the same arm label multiple times.
 
 To disable block randomisation, set \code{blocksizes} to the same value as \code{n}.
+
+It can be helpful to use smaller blocks at the start of a randomisation list.
+\code{n_small} allows you to define how many blocks to add at the beginning of
+the list with a different set of blocksize probabilities (entered via
+\code{init_probs})
 }
 \examples{
 # example code

--- a/tests/testthat/test-randolist.R
+++ b/tests/testthat/test-randolist.R
@@ -61,3 +61,9 @@ test_that("randolist errors or warns on invalid input", {
   expect_error(randolist(n = -1))
   expect_error(randolist(n = 5, arms = NULL))
 })
+
+test_that("error if incorrect number of init_probs supplied", {
+  expect_error(randolist(10, n_init = 3, init_probs = c(.9, .8, .1, 0)))
+  expect_error(randolist(10, n_init = 3, init_probs = 1))
+  expect_error(randolist(10, n_init = 3))
+})

--- a/vignettes/randotools.Rmd
+++ b/vignettes/randotools.Rmd
@@ -88,6 +88,32 @@ table(r2$arm)
 
 Adaptive trials sometimes modify the randomisation balance part way through a trial, which can be accomplished via this method.
 
+### More control over randomisation lists
+
+In some cases, such as relatively short randomisation lists including larger block sizes, it may be desirable to use smaller blocks at the beginning of a randomisation list. The `n_init` and `init_probs` arguments provide the means to accomplish that. They add `n_init` blocks to the beginning of the randomisation list (per strata) with blocksizes according to `init_probs`.
+
+For example, the following code will add 2 blocks with blocks of size 2 and 3 with probabilities of 0.8 and 0.2, respectively, and no blocks of size 6.
+
+```{r, eval=FALSE}
+randolist(n = 50, n_init = 2, init_probs = c(.8,.2,0))
+```
+
+We can go beyond the addition of `n_init` blocks to the beginning of the list. Using this method, we can use specific probabilities for the various blocksizes (by default, intermediate blocksizes are more frequent than the smallest/largest, when `pascal = TRUE`, or equal probabilities, when `pascal = FALSE`). In order to specify the probabilities for the full list, set `n_init` to some value large enough that the full list can be generated with the `n_init` blocks (e.g. `n_init` should be at least `n`/`min(blocksizes)`). For example, to generate a list with block sizes 2, 4 and 6 with probabilities of 0.7, .2, .1, i.e. prioritizing blocks of size 2, and 50 randomisations, we can use the following code:
+
+```{r}
+r <- randolist(n = 50, 
+          blocksizes = 1:3, # blocksizes*length(arms) = final blocksizes
+          n_init = 25, # 50/min(blocksizes*length(arms))
+          init_probs = c(.7,.2,.1))
+```
+
+This gives the following blocksize frequencies:
+
+```{r}
+table(r$blocksize)/c(2,4,6)
+```
+
+
 ## Summarizing randomisation lists
 
 It can be helpful to summarize the randomisation list to check that the requirements, such as the balance, coding, etc, are met. The `randolist` package includes a `summary` precisely for this purpose:


### PR DESCRIPTION
avoid large blocks at the beginning of a randomisation list by specifying custom blocksize probabilities for the first n blocks